### PR TITLE
Add agenda list command

### DIFF
--- a/adapters/spaggiari/adapter.go
+++ b/adapters/spaggiari/adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 const (
@@ -76,6 +77,49 @@ func (c Adapter) List() ([]Grade, error) {
 	}
 
 	return envelope["grades"], nil
+}
+
+func (c Adapter) ListAgenda(since, until time.Time) ([]AgendaEntry, error) {
+	identity, err := c.identityProvider.Get()
+	if err != nil {
+		return []AgendaEntry{}, err
+	}
+
+	_since := since.Format("20060102")
+	_until := until.Format("20060102")
+
+	url := baseUrl + "/students/" + identity.ID + "/agenda/all/" + _since + "/" + _until
+
+	fmt.Println(url)
+
+	req, err := c.newRequest("GET", url, nil, identity)
+	if err != nil {
+		return []AgendaEntry{}, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return []AgendaEntry{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return []AgendaEntry{}, fmt.Errorf("failed to fetch agenda entries, status_code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return []AgendaEntry{}, err
+	}
+
+	envelope := map[string][]AgendaEntry{}
+
+	err = json.Unmarshal(body, &envelope)
+	if err != nil {
+		return []AgendaEntry{}, err
+	}
+
+	return envelope["agenda"], nil
 }
 
 func (c Adapter) newRequest(method, url string, body io.Reader, identity Identity) (*http.Request, error) {

--- a/adapters/spaggiari/adapter.go
+++ b/adapters/spaggiari/adapter.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -89,8 +91,8 @@ func (c Adapter) ListAgenda(since, until time.Time) ([]AgendaEntry, error) {
 	_until := until.Format("20060102")
 
 	url := baseUrl + "/students/" + identity.ID + "/agenda/all/" + _since + "/" + _until
-
-	fmt.Println(url)
+	// fmt.Println(url)
+	log.Debug(url)
 
 	req, err := c.newRequest("GET", url, nil, identity)
 	if err != nil {

--- a/adapters/spaggiari/identity.go
+++ b/adapters/spaggiari/identity.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -28,22 +29,22 @@ type IdentityProvider struct {
 }
 
 func (p IdentityProvider) Get() (Identity, error) {
-	fmt.Println("checking loaderstorer for identity")
+	log.Debug("checking loaderstorer for identity")
 
 	identity, exists, err := p.LoaderStorer.Load()
 	if err != nil {
 		return Identity{}, err
 	}
 
-	fmt.Println("exists: ", exists)
+	log.Debug("exists: ", exists)
 
 	now := time.Now().Format(time.RFC3339)
 
-	fmt.Println("expire", identity.Expire)
-	fmt.Println("now", now)
+	log.Debug("expire", identity.Expire)
+	log.Debug("now", now)
 
 	if exists && now >= identity.Release && now < identity.Expire {
-		fmt.Println("reusing existing identity")
+		log.Debug("reusing existing identity")
 		return identity, nil
 	}
 
@@ -71,11 +72,11 @@ type InMemoryLoaderStorer struct {
 
 func (ls InMemoryLoaderStorer) Load() (Identity, bool, error) {
 	if ls.identity == noIdentity {
-		fmt.Println("identity is not available in the store")
+		log.Debug("identity is not available in the store")
 		return noIdentity, false, nil
 	}
 
-	fmt.Println("returning identity from the store")
+	log.Debug("returning identity from the store")
 	return ls.identity, true, nil
 }
 
@@ -158,7 +159,7 @@ type IdentityFetcher struct {
 }
 
 func (f IdentityFetcher) Fetch() (Identity, error) {
-	fmt.Println("fetching new identity")
+	log.Debug("fetching new identity")
 
 	creds := map[string]string{
 		"uid":  f.username,
@@ -190,7 +191,7 @@ func (f IdentityFetcher) Fetch() (Identity, error) {
 		return Identity{}, err
 	}
 
-	fmt.Println(string(body))
+	log.Debug(string(body))
 
 	identity := Identity{}
 

--- a/adapters/spaggiari/model.go
+++ b/adapters/spaggiari/model.go
@@ -19,3 +19,16 @@ type Grade struct {
 	Description   string  `json:"skillValueDesc"`
 	Notes         string  `json:"notesForFamily"`
 }
+
+type AgendaEntry struct {
+	ID            int    `json:"evtId"`            // "evtId": 502508,
+	Code          string `json:"evtCode"`          // "evtCode": "AGHW",
+	DatetimeBegin string `json:"evtDatetimeBegin"` // "evtDatetimeBegin": "2022-04-04T09:00:00+02:00",
+	DatetimeEnd   string `json:"evtDatetimeEnd"`   //	"evtDatetimeEnd": "2022-04-04T10:00:00+02:00",
+	Notes         string `json:"notes"`            // "notes": "Page 201 tutti gli esercizi",
+	AuthorName    string `json:"authorName"`       // "authorName": "PESANDO MARGHERITA",
+	Subject       string `json:"subjectDesc"`      // "INGLESE",
+	// "classDesc": "2E MUSICALE",
+	// "subjectId": 396137,
+	// "homeworkId": null
+}

--- a/commands/agenda.go
+++ b/commands/agenda.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/zmoog/classeviva/adapters/spaggiari"
+)
+
+type ListAgendaCommand struct {
+	Limit int
+}
+
+func (c ListAgendaCommand) Execute(adapter spaggiari.Adapter) error {
+
+	now := time.Now()
+	since := now
+	until := now.Add(5 * 24 * time.Hour)
+
+	fmt.Println(&now, "---", now)
+	fmt.Println(&since, "---", since)
+	fmt.Println(&until, "---", until)
+
+	entries, err := adapter.ListAgenda(since, until)
+	if err != nil {
+		return err
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	sort.Sort(AgendaEntryByDate(entries))
+
+	max := len(entries) - 1
+	if c.Limit > 0 && c.Limit < max {
+		max = c.Limit
+	}
+
+	output, _ := json.MarshalIndent(entries[:max], "", "  ")
+	fmt.Println(string(output))
+
+	return nil
+}
+
+type AgendaEntryByDate []spaggiari.AgendaEntry
+
+func (a AgendaEntryByDate) Len() int           { return len(a) }
+func (a AgendaEntryByDate) Less(i, j int) bool { return a[i].DatetimeBegin < a[j].DatetimeBegin }
+func (a AgendaEntryByDate) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/commands/agenda.go
+++ b/commands/agenda.go
@@ -11,19 +11,21 @@ import (
 
 type ListAgendaCommand struct {
 	Limit int
+	Since time.Time
+	Until time.Time
 }
 
 func (c ListAgendaCommand) Execute(adapter spaggiari.Adapter) error {
 
-	now := time.Now()
-	since := now
-	until := now.Add(5 * 24 * time.Hour)
+	// now := time.Now()
+	// since := now
+	// until := now.Add(5 * 24 * time.Hour)
 
-	fmt.Println(&now, "---", now)
-	fmt.Println(&since, "---", since)
-	fmt.Println(&until, "---", until)
+	// fmt.Println(&now, "---", now)
+	// fmt.Println(&since, "---", since)
+	// fmt.Println(&until, "---", until)
 
-	entries, err := adapter.ListAgenda(since, until)
+	entries, err := adapter.ListAgenda(c.Since, c.Until)
 	if err != nil {
 		return err
 	}

--- a/commands/agenda.go
+++ b/commands/agenda.go
@@ -21,19 +21,13 @@ func (c ListAgendaCommand) Execute(adapter spaggiari.Adapter) error {
 		return err
 	}
 
-	if len(entries) == 0 {
-		fmt.Println("No agenda entries for the given since/until interval")
-		return nil
-	}
-
 	sort.Sort(AgendaEntriesByDate(entries))
 
-	max := len(entries) - 1
-	if c.Limit > 0 && c.Limit < max {
-		max = c.Limit
+	if c.Limit < len(entries) {
+		entries = entries[:c.Limit]
 	}
 
-	output, _ := json.MarshalIndent(entries[:max], "", "  ")
+	output, _ := json.MarshalIndent(entries, "", "  ")
 	fmt.Println(string(output))
 
 	return nil

--- a/commands/agenda.go
+++ b/commands/agenda.go
@@ -16,15 +16,6 @@ type ListAgendaCommand struct {
 }
 
 func (c ListAgendaCommand) Execute(adapter spaggiari.Adapter) error {
-
-	// now := time.Now()
-	// since := now
-	// until := now.Add(5 * 24 * time.Hour)
-
-	// fmt.Println(&now, "---", now)
-	// fmt.Println(&since, "---", since)
-	// fmt.Println(&until, "---", until)
-
 	entries, err := adapter.ListAgenda(c.Since, c.Until)
 	if err != nil {
 		return err

--- a/commands/agenda.go
+++ b/commands/agenda.go
@@ -22,10 +22,11 @@ func (c ListAgendaCommand) Execute(adapter spaggiari.Adapter) error {
 	}
 
 	if len(entries) == 0 {
+		fmt.Println("No agenda entries for the given since/until interval")
 		return nil
 	}
 
-	sort.Sort(AgendaEntryByDate(entries))
+	sort.Sort(AgendaEntriesByDate(entries))
 
 	max := len(entries) - 1
 	if c.Limit > 0 && c.Limit < max {
@@ -38,8 +39,8 @@ func (c ListAgendaCommand) Execute(adapter spaggiari.Adapter) error {
 	return nil
 }
 
-type AgendaEntryByDate []spaggiari.AgendaEntry
+type AgendaEntriesByDate []spaggiari.AgendaEntry
 
-func (a AgendaEntryByDate) Len() int           { return len(a) }
-func (a AgendaEntryByDate) Less(i, j int) bool { return a[i].DatetimeBegin < a[j].DatetimeBegin }
-func (a AgendaEntryByDate) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a AgendaEntriesByDate) Len() int           { return len(a) }
+func (a AgendaEntriesByDate) Less(i, j int) bool { return a[i].DatetimeBegin < a[j].DatetimeBegin }
+func (a AgendaEntriesByDate) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/commands/grades.go
+++ b/commands/grades.go
@@ -2,8 +2,9 @@ package commands
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/zmoog/classeviva/adapters/spaggiari"
 )
@@ -27,7 +28,7 @@ func (c ListGradesCommand) Execute(adapter spaggiari.Adapter) error {
 	}
 
 	output, _ := json.MarshalIndent(grades[:max], "", "  ")
-	fmt.Println(string(output))
+	log.Debug(string(output))
 
 	return nil
 }

--- a/entrypoints/cli/cmd/agenda/agenda.go
+++ b/entrypoints/cli/cmd/agenda/agenda.go
@@ -1,0 +1,14 @@
+package agenda
+
+import "github.com/spf13/cobra"
+
+func NewCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "agenda",
+		Short: "Agenda",
+	}
+
+	cmd.AddCommand(initListCommand())
+
+	return &cmd
+}

--- a/entrypoints/cli/cmd/agenda/list.go
+++ b/entrypoints/cli/cmd/agenda/list.go
@@ -1,0 +1,40 @@
+package agenda
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/zmoog/classeviva/commands"
+)
+
+var (
+	limit int = 3
+)
+
+func initListCommand() *cobra.Command {
+	listCommand := cobra.Command{
+		Use:   "list",
+		Short: "List the agenda entries",
+		RunE:  runListCommand,
+	}
+
+	listCommand.Flags().IntVarP(&limit, "limit", "l", limit, "Limit number of results")
+
+	return &listCommand
+}
+
+func runListCommand(cmd *cobra.Command, args []string) error {
+	runner, err := commands.NewRunner()
+	if err != nil {
+		return err
+	}
+
+	command := commands.ListAgendaCommand{
+		Limit: limit,
+	}
+
+	err = runner.Run(command)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/entrypoints/cli/cmd/agenda/list.go
+++ b/entrypoints/cli/cmd/agenda/list.go
@@ -1,12 +1,17 @@
 package agenda
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/zmoog/classeviva/commands"
 )
 
 var (
 	limit int = 3
+	since string
+	until string
 )
 
 func initListCommand() *cobra.Command {
@@ -17,6 +22,8 @@ func initListCommand() *cobra.Command {
 	}
 
 	listCommand.Flags().IntVarP(&limit, "limit", "l", limit, "Limit number of results")
+	listCommand.Flags().StringVarP(&since, "since", "s", time.Now().Format("2006-01-02"), "Day to summarize (format: YYYY-MM-DD)")
+	listCommand.Flags().StringVarP(&until, "until", "u", time.Now().Add(3*24*time.Hour).Format("2006-01-02"), "Day to summarize (format: YYYY-MM-DD)")
 
 	return &listCommand
 }
@@ -27,8 +34,20 @@ func runListCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	_since, err := time.Parse("2006-01-02", since)
+	if err != nil {
+		return fmt.Errorf("invalid 'since' value: %w", err)
+	}
+
+	_until, err := time.Parse("2006-01-02", until)
+	if err != nil {
+		return fmt.Errorf("invalid 'until' value: %w", err)
+	}
+
 	command := commands.ListAgendaCommand{
 		Limit: limit,
+		Since: _since,
+		Until: _until,
 	}
 
 	err = runner.Run(command)

--- a/entrypoints/cli/cmd/root.go
+++ b/entrypoints/cli/cmd/root.go
@@ -4,21 +4,35 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/zmoog/classeviva/entrypoints/cli/cmd/agenda"
 	"github.com/zmoog/classeviva/entrypoints/cli/cmd/grades"
 )
 
+var (
+	debug bool
+)
+
 func Execute() {
 	var rootCmd = cobra.Command{
-		Use:   "classeviva",
-		Short: "Classeviva is a CLI tool to access the popular school portal https://web.spaggiari.eu/",
+		PersistentPreRun: setupRootFlags,
+		Use:              "classeviva",
+		Short:            "Classeviva is a CLI tool to access the popular school portal https://web.spaggiari.eu/",
 	}
+
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Print debug information")
 
 	rootCmd.AddCommand(agenda.NewCommand())
 	rootCmd.AddCommand(grades.NewCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+func setupRootFlags(cmd *cobra.Command, args []string) {
+	if debug {
+		log.SetLevel(log.DebugLevel)
 	}
 }

--- a/entrypoints/cli/cmd/root.go
+++ b/entrypoints/cli/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/zmoog/classeviva/entrypoints/cli/cmd/agenda"
 	"github.com/zmoog/classeviva/entrypoints/cli/cmd/grades"
 )
 
@@ -14,6 +15,7 @@ func Execute() {
 		Short: "Classeviva is a CLI tool to access the popular school portal https://web.spaggiari.eu/",
 	}
 
+	rootCmd.AddCommand(agenda.NewCommand())
 	rootCmd.AddCommand(grades.NewCommand())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/entrypoints/cli/cmd/root.go
+++ b/entrypoints/cli/cmd/root.go
@@ -16,7 +16,7 @@ var (
 
 func Execute() {
 	var rootCmd = cobra.Command{
-		PersistentPreRun: setupRootFlags,
+		PersistentPreRun: setupLogging,
 		Use:              "classeviva",
 		Short:            "Classeviva is a CLI tool to access the popular school portal https://web.spaggiari.eu/",
 	}
@@ -31,7 +31,7 @@ func Execute() {
 	}
 }
 
-func setupRootFlags(cmd *cobra.Command, args []string) {
+func setupLogging(cmd *cobra.Command, args []string) {
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,7 @@ require github.com/spf13/cobra v1.4.0
 
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,17 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want a `agenda list` command to list the agenda entries and know the homework assignments and other informations from the teachers.

```shell
$ classeviva agenda list --until 2022-04-27 --limit 2
[
  {
    "evtId": 550756,
    "evtCode": "AGNT",
    "evtDatetimeBegin": "2022-04-26T08:00:00+02:00",
    "evtDatetimeEnd": "2022-04-26T09:00:00+02:00",
    "notes": "PORTARE LETTERATURA",
    "authorName": "DICEMBRE ELISA",
    "subjectDesc": ""
  },
  {
    "evtId": 537508,
    "evtCode": "AGNT",
    "evtDatetimeBegin": "2022-04-26T11:00:00+02:00",
    "evtDatetimeEnd": "2022-04-26T12:00:00+02:00",
    "notes": "Studiare Intermezzo da Cavalleria rusticana. Interrogazione.",
    "authorName": "GRIMALDI ALESSANDRO",
    "subjectDesc": ""
  }
]
```

### Change description
<!-- What does your code do? -->

* Add `agenda list` command
* Add a simple logging setup to replace Printlns to optionally enable 

<!-- ### Additional Notes
Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.