### PR TITLE
Fix error message when running on a cloud provider

### DIFF
--- a/adapters/spaggiari/adapter.go
+++ b/adapters/spaggiari/adapter.go
@@ -26,9 +26,9 @@ func From(username, password, identityStorePath string) (Adapter, error) {
 		},
 		IdentityProvider: IdentityProvider{
 			Fetcher: IdentityFetcher{
-				username: username,
-				password: password,
-				client:   &httpClient,
+				Username: username,
+				Password: password,
+				Client:   &httpClient,
 			},
 			LoaderStorer: FilesystemLoaderStorer{
 				Path: identityStorePath,

--- a/adapters/spaggiari/http.go
+++ b/adapters/spaggiari/http.go
@@ -1,0 +1,7 @@
+package spaggiari
+
+import "net/http"
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}

--- a/adapters/spaggiari/identity.go
+++ b/adapters/spaggiari/identity.go
@@ -188,10 +188,10 @@ func (f IdentityFetcher) Fetch() (Identity, error) {
 
 	if resp.StatusCode != 200 {
 		switch resp.StatusCode {
-		case 401:
-			return Identity{}, fmt.Errorf("fetcher: unauthorized access to classeviva api (status_code: %v)", resp.StatusCode)
+		case 403:
+			return Identity{}, fmt.Errorf("fetcher: access denied to Classeviva API (status_code: %v). Hit: https://web.spaggiari.eu is not available to call from cloud provider.", resp.StatusCode)
 		default:
-			return Identity{}, fmt.Errorf("fetcher: failed to fetch identity (status_code: %v", resp.StatusCode)
+			return Identity{}, fmt.Errorf("fetcher: failed to fetch identity (status_code: %v)", resp.StatusCode)
 		}
 	}
 

--- a/adapters/spaggiari/identity.go
+++ b/adapters/spaggiari/identity.go
@@ -152,17 +152,17 @@ type Fetcher interface {
 }
 
 type IdentityFetcher struct {
-	client   *http.Client
-	username string
-	password string
+	Client   HTTPClient
+	Username string
+	Password string
 }
 
 func (f IdentityFetcher) Fetch() (Identity, error) {
 	log.Debug("fetching new identity")
 
 	creds := map[string]string{
-		"uid":  f.username,
-		"pass": f.password,
+		"uid":  f.Username,
+		"pass": f.Password,
 	}
 
 	payload, err := json.Marshal(creds)
@@ -179,7 +179,7 @@ func (f IdentityFetcher) Fetch() (Identity, error) {
 	req.Header.Add("Z-Dev-Apikey", "+zorro+")
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := f.client.Do(req)
+	resp, err := f.Client.Do(req)
 	if err != nil {
 		return Identity{}, err
 	}

--- a/adapters/spaggiari/identity.go
+++ b/adapters/spaggiari/identity.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -185,6 +186,15 @@ func (f IdentityFetcher) Fetch() (Identity, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		switch resp.StatusCode {
+		case 401:
+			return Identity{}, fmt.Errorf("fetcher: unauthorized access to classeviva api (status_code: %v)", resp.StatusCode)
+		default:
+			return Identity{}, fmt.Errorf("fetcher: failed to fetch identity (status_code: %v", resp.StatusCode)
+		}
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return Identity{}, err
@@ -195,7 +205,7 @@ func (f IdentityFetcher) Fetch() (Identity, error) {
 
 	err = json.Unmarshal(body, &identity)
 	if err != nil {
-		return Identity{}, err
+		return Identity{}, fmt.Errorf("fetcher: failed to unmarshal identity %w", err)
 	}
 
 	// The identity ID is made of the `ident` without the leading

--- a/adapters/spaggiari/identity_test.go
+++ b/adapters/spaggiari/identity_test.go
@@ -226,7 +226,7 @@ Reference&#32;&#35;18&#46;a6b93554&#46;1651609703&#46;877e15
 			Client: &mocks.MockClient{
 				MockDo: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
-						StatusCode: 401,
+						StatusCode: 403,
 						Body:       r,
 					}, nil
 				},
@@ -235,6 +235,6 @@ Reference&#32;&#35;18&#46;a6b93554&#46;1651609703&#46;877e15
 
 		_, err := fetcher.Fetch()
 
-		assert.ErrorContains(t, err, "fetcher: unauthorized access to classeviva api (status_code: 401)")
+		assert.ErrorContains(t, err, "fetcher: access denied to Classeviva API (status_code: 403). Hit: https://web.spaggiari.eu is not available to call from cloud provider.")
 	})
 }

--- a/adapters/spaggiari/identity_test.go
+++ b/adapters/spaggiari/identity_test.go
@@ -233,9 +233,8 @@ Reference&#32;&#35;18&#46;a6b93554&#46;1651609703&#46;877e15
 			},
 		}
 
-		identity, err := fetcher.Fetch()
+		_, err := fetcher.Fetch()
 
-		assert.Nil(t, identity)
-		assert.ErrorContains(t, err, "whatever")
+		assert.ErrorContains(t, err, "fetcher: unauthorized access to classeviva api (status_code: 401)")
 	})
 }

--- a/adapters/spaggiari/identity_test.go
+++ b/adapters/spaggiari/identity_test.go
@@ -1,7 +1,9 @@
 package spaggiari_test
 
 import (
+	"bytes"
 	"io/ioutil"
+	"net/http"
 	"testing"
 	"time"
 
@@ -202,5 +204,38 @@ func TestIdentityProvider(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, "123456", i.Ident)
+	})
+}
+
+func TestFetcher(t *testing.T) {
+	t.Run("From an unauthorized location", func(t *testing.T) {
+
+		response := `<TITLE>Access Denied</TITLE>
+</HEAD><BODY>
+<H1>Access Denied</H1>
+
+You don't have permission to access "http&#58;&#47;&#47;web&#46;spaggiari&#46;eu&#47;rest&#47;v1&#47;auth&#47;login&#47;" on this server.<P>
+Reference&#32;&#35;18&#46;a6b93554&#46;1651609703&#46;877e15
+</BODY>
+</HTML>`
+
+		// create a new reader with that JSON
+		r := ioutil.NopCloser(bytes.NewReader([]byte(response)))
+
+		fetcher := spaggiari.IdentityFetcher{
+			Client: &mocks.MockClient{
+				MockDo: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: 401,
+						Body:       r,
+					}, nil
+				},
+			},
+		}
+
+		identity, err := fetcher.Fetch()
+
+		assert.Nil(t, identity)
+		assert.ErrorContains(t, err, "whatever")
 	})
 }

--- a/mocks/http.go
+++ b/mocks/http.go
@@ -1,0 +1,14 @@
+package mocks
+
+import "net/http"
+
+type MockDoType func(req *http.Request) (*http.Response, error)
+
+// inspired by https://levelup.gitconnected.com/mocking-outbound-http-calls-in-golang-9e5a044c2555
+type MockClient struct {
+	MockDo MockDoType
+}
+
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
+	return m.MockDo(req)
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

According to #12, when classeviva is executed on a cloud provider (AWS, Azure) the HTTP request fails with a 401 but the error message is all about an obscure and unmarshalling issue.

```text
Error: invalid character '<' looking for beginning of value
```

We should do better in communicating to the user the issue and the possible next steps.

### Change description
<!-- What does your code do? -->

Check the HTTP status code in the response and reacts accordingly.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

Fixes #12 

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.