### PR TITLE
Add notarization for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,23 +13,32 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    # macOS notarization toolchain works only on macOS
+    runs-on: macos-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Fetch all tags
+      - name: Fetch all tags
         run: git fetch --force --tags
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      -
-        name: Run GoReleaser
+      - name: Install gon for code signing and notarization
+        run: |
+          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip -O /tmp/gon_macos.zip
+          unzip /tmp/gon_macos.zip -d /usr/local/bin          
+      - name: Set up keychain for macOS code-signing and notarization
+        env:
+          KEYCHAIN_PATH: "/tmp/apple-developer.keychain-db"
+        run: |
+          echo "${{ secrets.KEYCHAIN_CONTENT }}" | base64 --decode > ${{ env.KEYCHAIN_PATH }}
+          security default-keychain -s ${{ env.KEYCHAIN_PATH }}
+          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN_PATH }}"
+          git status
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
@@ -40,3 +49,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,8 @@
 # Binaries
 classeviva
 
+# goreleaser
 dist/
+
+# gon
+unused.*.zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,13 +7,44 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-  - env:
+  - binary: classeviva  
+    id: classeviva
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
       # - windows
-      - darwin
+      # - darwin
     main: ./entrypoints/cli
+  
+  - binary: classeviva
+    id: classeviva-macos-amd64
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    main: ./entrypoints/cli
+    hooks:
+      post:
+        - cmd: gon gon.config.amd64.hcl
+          output: true
+  
+  - binary: classeviva
+    id: classeviva-macos-arm64
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    main: ./entrypoints/cli
+    hooks:
+      post:
+        - cmd: gon gon.config.arm64.hcl
+          output: true
+  
 archives:
   - replacements:
       darwin: Darwin

--- a/gon.config.amd64.hcl
+++ b/gon.config.amd64.hcl
@@ -1,0 +1,14 @@
+source = [
+  "dist/classeviva-macos-amd64_darwin_amd64_v1/classeviva"
+]
+bundle_id = "dev.zmoog.classeviva"
+
+sign {
+  application_identity = "Developer ID Application: Maurizio Branca (47UB39QJQM)"
+}
+
+# Ask Gon for zip output to force notarization process to take place.
+# The CI will ignore the zip output, using the signed binary only.
+zip {
+  output_path = "unused.amd64.zip"
+}

--- a/gon.config.arm64.hcl
+++ b/gon.config.arm64.hcl
@@ -1,0 +1,14 @@
+source = [
+  "dist/classeviva-macos-arm64_darwin_arm64/classeviva"
+]
+bundle_id = "dev.zmoog.classeviva"
+
+sign {
+  application_identity = "Developer ID Application: Maurizio Branca (47UB39QJQM)"
+}
+
+# Ask Gon for zip output to force notarization process to take place.
+# The CI will ignore the zip output, using the signed binary only.
+zip {
+  output_path = "unused.arm64.zip"
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Modern macOS versions require the application binaries to be signed and notatized. 

### Change description
<!-- What does your code do? -->

Update the goreleaser pipeline with a post build hook that sign end notarize macOS binaries using [gon](https://github.com/mitchellh/gon).

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

Closes #8

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.