### PR TITLE
Add version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,8 @@ before:
 builds:
   - binary: classeviva  
     id: classeviva
+    ldflags:
+      - -s -w -X github.com/zmoog/classeviva/commands.version={{.Version}} -X github.com/zmoog/classeviva/commands.commit={{.Commit}} -X github.com/zmoog/classeviva/commands.date={{.Date}} -X github.com/zmoog/classeviva/commands.builtBy=goreleaser
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,6 +21,8 @@ builds:
   
   - binary: classeviva
     id: classeviva-macos-amd64
+    ldflags:
+      - -s -w -X github.com/zmoog/classeviva/commands.version={{.Version}} -X github.com/zmoog/classeviva/commands.commit={{.Commit}} -X github.com/zmoog/classeviva/commands.date={{.Date}} -X github.com/zmoog/classeviva/commands.builtBy=goreleaser
     env:
       - CGO_ENABLED=0
     goos:
@@ -33,6 +37,8 @@ builds:
   
   - binary: classeviva
     id: classeviva-macos-arm64
+    ldflags:
+      - -s -w -X github.com/zmoog/classeviva/commands.version={{.Version}} -X github.com/zmoog/classeviva/commands.commit={{.Commit}} -X github.com/zmoog/classeviva/commands.date={{.Date}} -X github.com/zmoog/classeviva/commands.builtBy=goreleaser
     env:
       - CGO_ENABLED=0
     goos:

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/zmoog/classeviva/adapters/feedback"
+)
+
+var (
+	version string = "v0.0.0"
+	commit  string = "123"
+	date    string = "2022-05-08"
+	builtBy string = "zmoog"
+)
+
+type VersionCommand struct{}
+
+func (c VersionCommand) ExecuteWith(uow UnitOfWork) error {
+	return feedback.PrintResult(VersionResult{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+		BuiltBy: builtBy,
+	})
+}
+
+type VersionResult struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+	BuiltBy string `json:"built_by"`
+}
+
+func (r VersionResult) String() string {
+	return fmt.Sprintf("Classeviva CLI %v (%v) %v by %v", version, commit, date, builtBy)
+}
+
+func (r VersionResult) Data() interface{} {
+	return r
+}

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -1,0 +1,58 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zmoog/classeviva/adapters/feedback"
+	"github.com/zmoog/classeviva/commands"
+	"github.com/zmoog/classeviva/mocks"
+)
+
+func TestVersion(t *testing.T) {
+	t.Run("Text version", func(t *testing.T) {
+		mockAdapter := mocks.Adapter{}
+
+		stdout := bytes.Buffer{}
+		stderr := bytes.Buffer{}
+		fb := feedback.New(&stdout, &stderr, feedback.Text)
+		feedback.SetDefault(fb)
+
+		uow := commands.UnitOfWork{Adapter: &mockAdapter, Feedback: fb}
+
+		cmd := commands.VersionCommand{}
+
+		err := cmd.ExecuteWith(uow)
+		assert.Nil(t, err)
+
+		assert.Equal(t, "Classeviva CLI v0.0.0 (123) 2022-05-08 by zmoog", stdout.String())
+		assert.Equal(t, "", stderr.String())
+	})
+
+	t.Run("JSON version", func(t *testing.T) {
+		mockAdapter := mocks.Adapter{}
+
+		stdout := bytes.Buffer{}
+		stderr := bytes.Buffer{}
+		fb := feedback.New(&stdout, &stderr, feedback.JSON)
+		feedback.SetDefault(fb)
+
+		uow := commands.UnitOfWork{Adapter: &mockAdapter, Feedback: fb}
+
+		cmd := commands.VersionCommand{}
+
+		err := cmd.ExecuteWith(uow)
+		assert.Nil(t, err)
+
+		expectedJSON := `{
+  "version": "v0.0.0",
+  "commit": "123",
+  "date": "2022-05-08",
+  "built_by": "zmoog"
+}`
+
+		assert.Equal(t, expectedJSON, stdout.String())
+		assert.Equal(t, "", stderr.String())
+	})
+}

--- a/entrypoints/cli/cmd/root.go
+++ b/entrypoints/cli/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zmoog/classeviva/adapters/feedback"
 	"github.com/zmoog/classeviva/entrypoints/cli/cmd/agenda"
 	"github.com/zmoog/classeviva/entrypoints/cli/cmd/grades"
+	"github.com/zmoog/classeviva/entrypoints/cli/cmd/version"
 )
 
 var (
@@ -25,6 +26,7 @@ func Execute() {
 
 	rootCmd.AddCommand(agenda.NewCommand())
 	rootCmd.AddCommand(grades.NewCommand())
+	rootCmd.AddCommand(version.NewCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		feedback.Error(err)

--- a/entrypoints/cli/cmd/version/version.go
+++ b/entrypoints/cli/cmd/version/version.go
@@ -1,0 +1,32 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/zmoog/classeviva/commands"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "version",
+		Short: "Prints the application version",
+		RunE:  runVersionCommand,
+	}
+
+	return &cmd
+}
+
+func runVersionCommand(cmd *cobra.Command, args []string) error {
+	command := commands.VersionCommand{}
+
+	runner, err := commands.NewRunner()
+	if err != nil {
+		return err
+	}
+
+	err = runner.Run(command)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want a simple `version` command, for example:

```shell
$ classeviva version
Classeviva CLI 0.1.3-next (89145010a5f178339d5b925321ba2d1d9185591d) 2022-05-08T17:41:57Z by goreleaser

$ classeviva version --format json
{
  "version": "0.1.3-next",
  "commit": "708048eca27a86ee51be5c8de369574c266fae74",
  "date": "2022-05-08T18:13:36Z",
  "built_by": "goreleaser"
}
```

### Change description
<!-- What does your code do? -->

Add a new `version` command that print version in text and JSON formats.

Update the goreleaser pipeline to inject the build values using the ldflags mechanism.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

Closes: #16

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.