### PR TITLE
Update user agent and api key

### DIFF
--- a/adapters/spaggiari/adapter.go
+++ b/adapters/spaggiari/adapter.go
@@ -10,18 +10,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	baseUrl = "https://web.spaggiari.eu/rest/v1"
-)
-
 func From(username, password, identityStorePath string) (Adapter, error) {
 	httpClient := http.Client{}
 
 	adapter := spaggiariAdapter{
 		client: &httpClient,
 		headers: map[string]string{
-			"User-Agent":   "zorro/1.0",
-			"Z-Dev-Apikey": "+zorro+",
+			"User-Agent":   userAgent,
+			"Z-Dev-Apikey": apiKey,
 			"Content-Type": "application/json",
 		},
 		IdentityProvider: IdentityProvider{

--- a/adapters/spaggiari/http.go
+++ b/adapters/spaggiari/http.go
@@ -2,6 +2,12 @@ package spaggiari
 
 import "net/http"
 
+const (
+	baseUrl   = "https://web.spaggiari.eu/rest/v1"
+	apiKey    = "Tg1NWEwNGIgIC0K"
+	userAgent = "CVVS/std/4.2.3 Android/12"
+)
+
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }

--- a/adapters/spaggiari/identity.go
+++ b/adapters/spaggiari/identity.go
@@ -176,8 +176,8 @@ func (f IdentityFetcher) Fetch() (Identity, error) {
 		return Identity{}, err
 	}
 
-	req.Header.Add("User-Agent", "CVVS/std/4.2.3 Android/12")
-	req.Header.Add("Z-Dev-Apikey", "Tg1NWEwNGIgIC0K")
+	req.Header.Add("User-Agent", userAgent)
+	req.Header.Add("Z-Dev-Apikey", apiKey)
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := f.Client.Do(req)

--- a/adapters/spaggiari/identity.go
+++ b/adapters/spaggiari/identity.go
@@ -176,8 +176,8 @@ func (f IdentityFetcher) Fetch() (Identity, error) {
 		return Identity{}, err
 	}
 
-	req.Header.Add("User-Agent", "zorro/1.0")
-	req.Header.Add("Z-Dev-Apikey", "+zorro+")
+	req.Header.Add("User-Agent", "CVVS/std/4.2.3 Android/12")
+	req.Header.Add("Z-Dev-Apikey", "Tg1NWEwNGIgIC0K")
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := f.Client.Do(req)


### PR DESCRIPTION
The previous ones are no longer valid.

I found a working pair of user-agent and api-key by searching GitHub for the login URL. Here's the link to the commit hash:

https://github.com/Lioydiano/Classeviva/commit/503e77f708a9bde4e77ccc2050493d576360bc9a

Closes: zmoog/classeviva#21