### PR TITLE
Switch from golang 1.17 to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.9'
+          go-version: '1.20.2'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.9'
+          go-version: '1.20.2'
       - run: make test
   build:
     name: Build binaries
@@ -45,5 +45,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.9'
+          go-version: '1.20.2'
       - run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20.2
       - name: Install gon for code signing and notarization
         run: |
           wget -q https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip -O /tmp/gon_macos.zip

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.17.9
-golangci-lint 1.42.1
+golang 1.20.2
+golangci-lint 1.52.0
 mockery 2.12.0

--- a/adapters/spaggiari/identity.go
+++ b/adapters/spaggiari/identity.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func (ls FilesystemLoaderStorer) Load() (Identity, bool, error) {
 		return noIdentity, false, nil
 	}
 
-	data, err := ioutil.ReadFile(configFilePath)
+	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return noIdentity, false, err
 	}
@@ -128,7 +127,7 @@ func (ls FilesystemLoaderStorer) Store(identity Identity) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(path, "identity.json"), data, 0700)
+	err = os.WriteFile(filepath.Join(path, "identity.json"), data, 0700)
 	if err != nil {
 		return err
 	}

--- a/adapters/spaggiari/identity_test.go
+++ b/adapters/spaggiari/identity_test.go
@@ -2,8 +2,9 @@ package spaggiari_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func TestInMemoryLoaderStorer(t *testing.T) {
 
 func TestFilesystemLoaderStorer(t *testing.T) {
 	t.Run("Load from empty an store", func(t *testing.T) {
-		path, err := ioutil.TempDir("", "")
+		path, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -72,7 +73,7 @@ func TestFilesystemLoaderStorer(t *testing.T) {
 	})
 
 	t.Run("Store and load the identity", func(t *testing.T) {
-		path, err := ioutil.TempDir("", "")
+		path, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Error(err)
 		}
@@ -220,7 +221,7 @@ Reference&#32;&#35;18&#46;a6b93554&#46;1651609703&#46;877e15
 </HTML>`
 
 		// create a new reader with that JSON
-		r := ioutil.NopCloser(bytes.NewReader([]byte(response)))
+		r := io.NopCloser(bytes.NewReader([]byte(response)))
 
 		fetcher := spaggiari.IdentityFetcher{
 			Client: &mocks.MockClient{

--- a/commands/agenda_test.go
+++ b/commands/agenda_test.go
@@ -2,7 +2,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +63,7 @@ func TestListAgendaCommand(t *testing.T) {
 		err := cmd.ExecuteWith(uow)
 		assert.Nil(t, err)
 
-		expected, err := ioutil.ReadFile("testdata/agenda.out.txt")
+		expected, err := os.ReadFile("testdata/agenda.out.txt")
 		if err != nil {
 			t.Errorf("can't read test data from %v: %v", "testdata/agenda.out.txt", err)
 		}

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -19,7 +18,7 @@ func UnmarshalFrom(path string, v interface{}) error {
 		return fmt.Errorf("can't read from %v", path)
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("can't read test data from %v: %w", path, err)
 	}

--- a/commands/grades_test.go
+++ b/commands/grades_test.go
@@ -2,7 +2,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,7 +56,7 @@ func TestListGradesCommand(t *testing.T) {
 		err := cmd.ExecuteWith(uow)
 		assert.Nil(t, err)
 
-		expected, err := ioutil.ReadFile("testdata/grades.out.txt")
+		expected, err := os.ReadFile("testdata/grades.out.txt")
 		if err != nil {
 			t.Errorf("can't read test data from %v: %v", "testdata/grades.out.txt", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zmoog/classeviva
 
-go 1.17
+go 1.20
 
 require (
 	github.com/jedib0t/go-pretty/v6 v6.3.1


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The golang version 1.17 is getting older, so it's time to catch up with the ecosystem. 

### Change description
<!-- What does your code do? -->

Currently targeting golang 1.20.2.

With the golang upgrade we also fixed the following:

- fixed deprecated API usage (mostly `ioutil` to `os`)
- bumped golangci-lint to 1.52.0

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.