### PR TITLE
Disable macOS notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,29 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.20.2
-      - name: Install gon for code signing and notarization
-        run: |
-          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip -O /tmp/gon_macos.zip
-          unzip /tmp/gon_macos.zip -d /usr/local/bin          
-      - name: Set up keychain for macOS code-signing and notarization
-        env:
-          KEYCHAIN_PATH: "/tmp/apple-developer.keychain-db"
-        run: |
-          echo "${{ secrets.KEYCHAIN_CONTENT }}" | base64 --decode > ${{ env.KEYCHAIN_PATH }}
-          security default-keychain -s ${{ env.KEYCHAIN_PATH }}
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN_PATH }}"
-          git status
+      #
+      # Uncomment the following lines if you want to use macOS notarization
+      # ---------------------------------------------------------------
+      #
+      # I have commented out the following lines because I don't have a
+      # paid Apple Developer account anymore.
+      # 
+      # Since I'm probably the only one who will ever use this, I'm not
+      # goint to spend $99/year until I have a good reason to do so.
+      #
+      # - name: Install gon for code signing and notarization
+      #   run: |
+      #     wget -q https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip -O /tmp/gon_macos.zip
+      #     unzip /tmp/gon_macos.zip -d /usr/local/bin          
+      # - name: Set up keychain for macOS code-signing and notarization
+      #   env:
+      #     KEYCHAIN_PATH: "/tmp/apple-developer.keychain-db"
+      #   run: |
+      #     echo "${{ secrets.KEYCHAIN_CONTENT }}" | base64 --decode > ${{ env.KEYCHAIN_PATH }}
+      #     security default-keychain -s ${{ env.KEYCHAIN_PATH }}
+      #     security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN_PATH }}"
+      #     git status
+      
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,40 +16,51 @@ builds:
     goos:
       - linux
       # - windows
-      # - darwin
+      - darwin
     main: ./entrypoints/cli
   
-  - binary: classeviva
-    id: classeviva-macos-amd64
-    ldflags:
-      - -s -w -X github.com/zmoog/classeviva/commands.version={{.Version}} -X github.com/zmoog/classeviva/commands.commit={{.Commit}} -X github.com/zmoog/classeviva/commands.date={{.Date}} -X github.com/zmoog/classeviva/commands.builtBy=goreleaser
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    main: ./entrypoints/cli
-    hooks:
-      post:
-        - cmd: gon gon.config.amd64.hcl
-          output: true
+  #
+  # Uncomment the following lines if you want to use macOS notarization
+  # ---------------------------------------------------------------
+  #
+  # I have commented out the following lines because I don't have a
+  # paid Apple Developer account anymore.
+  # 
+  # Since I'm probably the only one who will ever use this, I'm not
+  # goint to spend $99/year until I have a good reason to do so.
+  #
+    
+  # - binary: classeviva
+  #   id: classeviva-macos-amd64
+  #   ldflags:
+  #     - -s -w -X github.com/zmoog/classeviva/commands.version={{.Version}} -X github.com/zmoog/classeviva/commands.commit={{.Commit}} -X github.com/zmoog/classeviva/commands.date={{.Date}} -X github.com/zmoog/classeviva/commands.builtBy=goreleaser
+  #   env:
+  #     - CGO_ENABLED=0
+  #   goos:
+  #     - darwin
+  #   goarch:
+  #     - amd64
+  #   main: ./entrypoints/cli
+  #   hooks:
+  #     post:
+  #       - cmd: gon gon.config.amd64.hcl
+  #         output: true
   
-  - binary: classeviva
-    id: classeviva-macos-arm64
-    ldflags:
-      - -s -w -X github.com/zmoog/classeviva/commands.version={{.Version}} -X github.com/zmoog/classeviva/commands.commit={{.Commit}} -X github.com/zmoog/classeviva/commands.date={{.Date}} -X github.com/zmoog/classeviva/commands.builtBy=goreleaser
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    main: ./entrypoints/cli
-    hooks:
-      post:
-        - cmd: gon gon.config.arm64.hcl
-          output: true
+  # - binary: classeviva
+  #   id: classeviva-macos-arm64
+  #   ldflags:
+  #     - -s -w -X github.com/zmoog/classeviva/commands.version={{.Version}} -X github.com/zmoog/classeviva/commands.commit={{.Commit}} -X github.com/zmoog/classeviva/commands.date={{.Date}} -X github.com/zmoog/classeviva/commands.builtBy=goreleaser
+  #   env:
+  #     - CGO_ENABLED=0
+  #   goos:
+  #     - darwin
+  #   goarch:
+  #     - arm64
+  #   main: ./entrypoints/cli
+  #   hooks:
+  #     post:
+  #       - cmd: gon gon.config.arm64.hcl
+  #         output: true
   
 archives:
   - replacements:


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I no longer have a paid Apple Developer account, so I don't like spending $99/year to notarize a CLI tool, for which I'm probably the only user.

I'll reenable the notarization once I'll have an Apple Developer account for a good reason.

### Change description
<!-- What does your code do? -->

Comment out the workflow steps that perform the macOS notarization.

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] ~~Changes are covered by tests.~~
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.