### PR TITLE
feat: improve agenda list output

### DIFF
--- a/adapters/spaggiari/model.go
+++ b/adapters/spaggiari/model.go
@@ -28,6 +28,7 @@ type AgendaEntry struct {
 	Notes         string `json:"notes"`            // "notes": "Page 201 tutti gli esercizi",
 	AuthorName    string `json:"authorName"`       // "authorName": "PESANDO MARGHERITA",
 	Subject       string `json:"subjectDesc"`      // "INGLESE",
+	IsFullDay     bool   `json:"isFullDay"`
 	// "classDesc": "2E MUSICALE",
 	// "subjectId": 396137,
 	// "homeworkId": null

--- a/commands/agenda.go
+++ b/commands/agenda.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/zmoog/classeviva/adapters/feedback"
 	"github.com/zmoog/classeviva/adapters/spaggiari"
 )
@@ -47,16 +49,30 @@ func (r AgendaEntriesResult) String() string {
 	}
 
 	t := table.NewWriter()
+	t.SetStyle(table.StyleColoredBright)
 	t.SetColumnConfigs([]table.ColumnConfig{{Number: 1, AutoMerge: true}})
 
-	t.AppendHeader(table.Row{"Begin", "End", "Subject", "Teacher", "Notes"})
+	t.AppendHeader(table.Row{"Time", "Subject", "Teacher", "Notes"})
 	for _, e := range r.Entries {
+		// Optimize the time formatting for visualization
+		datetimeBegin, _ := time.Parse(time.RFC3339, e.DatetimeBegin)
+		datetimeEnd, _ := time.Parse(time.RFC3339, e.DatetimeEnd)
+		timeInt := fmt.Sprintf("%s - %s", datetimeBegin.Format("02-01-2006 15:04"), datetimeEnd.Format("02-01-2006 15:04"))
+		if e.IsFullDay {
+			timeInt = fmt.Sprintf("%s (all day)", datetimeBegin.Format("02-01-2006"))
+		}
+
+		// Use a placeholder for the subject if it's empty
+		subject := "-"
+		if e.Subject != "" {
+			subject = e.Subject
+		}
+
 		t.AppendRow(table.Row{
-			e.DatetimeBegin,
-			e.DatetimeEnd,
-			e.Subject,
+			timeInt,
+			subject,
 			e.AuthorName,
-			e.Notes,
+			text.WrapSoft(e.Notes, 50),
 		})
 	}
 

--- a/commands/testdata/agenda.out.txt
+++ b/commands/testdata/agenda.out.txt
@@ -1,10 +1,9 @@
-+---------------------------+---------------------------+------------+--------------------+-------------------------------------------------------------------------------------+
-| BEGIN                     | END                       | SUBJECT    | TEACHER            | NOTES                                                                               |
-+---------------------------+---------------------------+------------+--------------------+-------------------------------------------------------------------------------------+
-| 2022-05-02T09:00:00+02:00 | 2022-05-02T10:00:00+02:00 |            | PESANDO MARGHERITA | Inizio interrogazioni di inglese (1º turno)                                         |
-| 2022-05-03T12:00:00+02:00 | 2022-05-03T13:00:00+02:00 |            | ROMEO ENRICA       | studiare bene la regola di p.139 e il verbo di p. 141; ex p. 139 n.3-4; p. 141 n.10 |
-| 2022-05-04T08:00:00+02:00 | 2022-05-04T09:00:00+02:00 |            | PESANDO MARGHERITA | 2º turno interrogazioni inglese                                                     |
-| 2022-05-04T12:00:00+02:00 | 2022-05-04T13:00:00+02:00 |            | MEGNA VALERIA      | Consegna Programma di Lavoro EDIL-LAB  (v. spiegazioni in Classroom)                |
-| 2022-05-05T11:00:00+02:00 | 2022-05-05T12:00:00+02:00 | MATEMATICA | ULLA ALICE         | Geometria: pagina 50 n.217-218.                                                     |
-| 2022-05-09T09:00:00+02:00 | 2022-05-09T10:00:00+02:00 |            | PESANDO MARGHERITA | 3º turno interrogazioni inglese                                                     |
-+---------------------------+---------------------------+------------+--------------------+-------------------------------------------------------------------------------------+
+[106;30m TIME                                [0m[106;30m SUBJECT    [0m[106;30m TEACHER            [0m[106;30m NOTES                                              [0m
+[107;30m 02-05-2022 09:00 - 02-05-2022 10:00 [0m[107;30m -          [0m[107;30m PESANDO MARGHERITA [0m[107;30m Inizio interrogazioni di inglese (1º turno)        [0m
+[47;30m 03-05-2022 12:00 - 03-05-2022 13:00 [0m[47;30m -          [0m[47;30m ROMEO ENRICA       [0m[47;30m studiare bene la regola di p.139 e il verbo di p.  [0m
+[47;30m                                     [0m[47;30m            [0m[47;30m                    [0m[47;30m 141; ex p. 139 n.3-4; p. 141 n.10                  [0m
+[107;30m 04-05-2022 08:00 - 04-05-2022 09:00 [0m[107;30m -          [0m[107;30m PESANDO MARGHERITA [0m[107;30m 2º turno interrogazioni inglese                    [0m
+[47;30m 04-05-2022 12:00 - 04-05-2022 13:00 [0m[47;30m -          [0m[47;30m MEGNA VALERIA      [0m[47;30m Consegna Programma di Lavoro EDIL-LAB (v.          [0m
+[47;30m                                     [0m[47;30m            [0m[47;30m                    [0m[47;30m spiegazioni in Classroom)                          [0m
+[107;30m 05-05-2022 11:00 - 05-05-2022 12:00 [0m[107;30m MATEMATICA [0m[107;30m ULLA ALICE         [0m[107;30m Geometria: pagina 50 n.217-218.                    [0m
+[47;30m 09-05-2022 09:00 - 09-05-2022 10:00 [0m[47;30m -          [0m[47;30m PESANDO MARGHERITA [0m[47;30m 3º turno interrogazioni inglese                    [0m


### PR DESCRIPTION
Improve the output of `classeviva agenda list` (the function I use the most :) by:
- Use a color schema to better identify rows
- Support "all day" flag to reduce clutter (To do that, I had to introduce support for the `isFullDay` JSON field)
- Use a placeholder when subject is not set
- Wrap the notes column to fit the average terminal

Example: 
<img width="1173" height="179" alt="image" src="https://github.com/user-attachments/assets/a3304865-5714-4b7c-9eac-06bf8308c40d" />


Notes for the reviewer:
- I had to re-generate the output test file to account for the table changes, but it's going to be cumbersome having to change the test file at every change to the table. I'm not sure testing the actual output is super helpful, I would be happy asserting the data we want is there, one color or another :)